### PR TITLE
feat: watchlist cards with live data, reorder, remove

### DIFF
--- a/src/app/api/watchlist/helpers.ts
+++ b/src/app/api/watchlist/helpers.ts
@@ -60,7 +60,8 @@ export function mapWatchlistRows(rows: WatchlistItemRow[]): WatchlistItem[] {
 
 export function mapWatchlistRowsWithLogo(
   rows: WatchlistItemRow[],
-  logoMap: Record<string, string | null>
+  logoMap: Record<string, string | null>,
+  nameMap: Record<string, string | null>
 ): WatchlistItem[] {
   return rows.map((row) => ({
     id: row.id,
@@ -68,6 +69,7 @@ export function mapWatchlistRowsWithLogo(
     position: row.position,
     createdAt: row.created_at,
     logoUrl: logoMap[row.ticker] ?? null,
+    name: nameMap[row.ticker] ?? null,
   }));
 }
 

--- a/src/app/api/watchlist/reorder/route.ts
+++ b/src/app/api/watchlist/reorder/route.ts
@@ -3,10 +3,11 @@ import { supabaseRestFetch } from '@/lib/supabase';
 import {
   MAX_WATCHLIST_ITEMS,
   fetchWatchlistRows,
-  mapWatchlistRows,
+  mapWatchlistRowsWithLogo,
   normalizeTicker,
   resolveUserId,
 } from '../helpers';
+import { getLogoUrl, listAssets } from '@/lib/alpaca';
 
 export async function PATCH(req: NextRequest) {
   try {
@@ -79,7 +80,19 @@ export async function PATCH(req: NextRequest) {
     });
 
     const rows = await fetchWatchlistRows(userId);
-    return NextResponse.json({ items: mapWatchlistRows(rows) });
+    const logoEntries = await Promise.all(
+      rows.map(async (row) => [row.ticker, await getLogoUrl(row.ticker)] as const)
+    );
+    const assets = await listAssets();
+    const nameMap = assets.reduce<Record<string, string | null>>((acc, asset) => {
+      if (asset.symbol) acc[asset.symbol.toUpperCase()] = asset.name ?? null;
+      return acc;
+    }, {});
+    const logoMap = logoEntries.reduce<Record<string, string | null>>((acc, [ticker, logoUrl]) => {
+      acc[ticker] = logoUrl;
+      return acc;
+    }, {});
+    return NextResponse.json({ items: mapWatchlistRowsWithLogo(rows, logoMap, nameMap) });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Failed to reorder watchlist';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/api/watchlist/reorder/route.ts
+++ b/src/app/api/watchlist/reorder/route.ts
@@ -70,7 +70,7 @@ export async function PATCH(req: NextRequest) {
       position: index,
     }));
 
-    await supabaseRestFetch('/rest/v1/watchlist_items', {
+    await supabaseRestFetch('/rest/v1/watchlist_items?on_conflict=user_id,ticker', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/app/api/watchlist/route.ts
+++ b/src/app/api/watchlist/route.ts
@@ -8,7 +8,7 @@ import {
   resolveUserId,
   validateTicker,
 } from './helpers';
-import { getLogoUrl } from '@/lib/alpaca';
+import { getLogoUrl, listAssets } from '@/lib/alpaca';
 
 export async function GET(req: NextRequest) {
   try {
@@ -21,11 +21,16 @@ export async function GET(req: NextRequest) {
     const logoEntries = await Promise.all(
       rows.map(async (row) => [row.ticker, await getLogoUrl(row.ticker)] as const)
     );
+    const assets = await listAssets();
+    const nameMap = assets.reduce<Record<string, string | null>>((acc, asset) => {
+      if (asset.symbol) acc[asset.symbol.toUpperCase()] = asset.name ?? null;
+      return acc;
+    }, {});
     const logoMap = logoEntries.reduce<Record<string, string | null>>((acc, [ticker, logoUrl]) => {
       acc[ticker] = logoUrl;
       return acc;
     }, {});
-    return NextResponse.json({ items: mapWatchlistRowsWithLogo(rows, logoMap) });
+    return NextResponse.json({ items: mapWatchlistRowsWithLogo(rows, logoMap, nameMap) });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Failed to load watchlist';
     return NextResponse.json({ error: message }, { status: 500 });
@@ -77,11 +82,16 @@ export async function POST(req: NextRequest) {
     const logoEntries = await Promise.all(
       rows.map(async (row) => [row.ticker, await getLogoUrl(row.ticker)] as const)
     );
+    const assets = await listAssets();
+    const nameMap = assets.reduce<Record<string, string | null>>((acc, asset) => {
+      if (asset.symbol) acc[asset.symbol.toUpperCase()] = asset.name ?? null;
+      return acc;
+    }, {});
     const logoMap = logoEntries.reduce<Record<string, string | null>>((acc, [ticker, logoUrl]) => {
       acc[ticker] = logoUrl;
       return acc;
     }, {});
-    return NextResponse.json({ items: mapWatchlistRowsWithLogo(rows, logoMap) });
+    return NextResponse.json({ items: mapWatchlistRowsWithLogo(rows, logoMap, nameMap) });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Failed to update watchlist';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/watchlist/page.tsx
+++ b/src/app/watchlist/page.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
-import { Search, Sparkles, Plus, X, Loader2 } from 'lucide-react';
+import { Search, Sparkles, Plus, X, Loader2, GripVertical, Trash2, RefreshCw } from 'lucide-react';
 import { USER_HEADER_KEY, USER_ID_STORAGE_KEY } from '@/lib/portfolio-drafts';
-import type { WatchlistItem } from '@/types';
+import type { StockDetailsSummary, WatchlistItem } from '@/types';
 
 type SearchResult = {
   ticker: string;
@@ -30,11 +30,47 @@ function formatPercent(value?: number | null) {
   return `${(value * 100).toFixed(2)}%`;
 }
 
+function Sparkline({ points }: { points?: number[] }) {
+  if (!points || points.length < 2) {
+    return <div className="h-6 w-20 rounded-full bg-gray-100 dark:bg-gray-800" />;
+  }
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const range = max - min || 1;
+  const width = 80;
+  const height = 24;
+  const step = width / (points.length - 1);
+  const coords = points
+    .map((value, index) => {
+      const x = index * step;
+      const y = height - ((value - min) / range) * height;
+      return `${x},${y}`;
+    })
+    .join(' ');
+  const up = points[points.length - 1] >= points[0];
+  const stroke = up ? '#16a34a' : '#dc2626';
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} className="overflow-visible">
+      <polyline
+        fill="none"
+        stroke={stroke}
+        strokeWidth="2"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        points={coords}
+      />
+    </svg>
+  );
+}
+
 export default function WatchlistPage() {
   const [userId, setUserId] = useState<string | null>(null);
   const [items, setItems] = useState<WatchlistItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [detailsMap, setDetailsMap] = useState<Record<string, StockDetailsSummary | null>>({});
+  const [detailsLoading, setDetailsLoading] = useState(false);
+  const [detailsError, setDetailsError] = useState<string | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
@@ -42,6 +78,7 @@ export default function WatchlistPage() {
   const [searchError, setSearchError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [addingTicker, setAddingTicker] = useState<string | null>(null);
+  const [draggingTicker, setDraggingTicker] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -64,6 +101,38 @@ export default function WatchlistPage() {
     [items]
   );
 
+  const maxReached = items.length >= 50;
+
+  const fetchDetails = async (tickers: string[]) => {
+    if (!tickers.length) {
+      setDetailsMap({});
+      return;
+    }
+    setDetailsLoading(true);
+    setDetailsError(null);
+    try {
+      const entries = await Promise.all(
+        tickers.map(async (ticker) => {
+          const res = await fetch(`/api/stocks/${encodeURIComponent(ticker)}/details`);
+          if (!res.ok) return [ticker, null] as const;
+          const data = (await res.json()) as { summary?: StockDetailsSummary };
+          return [ticker, data?.summary ?? null] as const;
+        })
+      );
+      setDetailsMap(
+        entries.reduce<Record<string, StockDetailsSummary | null>>((acc, [ticker, summary]) => {
+          acc[ticker] = summary;
+          return acc;
+        }, {})
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load watchlist data';
+      setDetailsError(message);
+    } finally {
+      setDetailsLoading(false);
+    }
+  };
+
   const refreshWatchlist = async () => {
     if (!userId) return;
     setLoading(true);
@@ -77,7 +146,9 @@ export default function WatchlistPage() {
         throw new Error(text || `Failed to load watchlist (${res.status})`);
       }
       const data = (await res.json()) as { items?: WatchlistItem[] };
-      setItems(Array.isArray(data.items) ? data.items : []);
+      const nextItems = Array.isArray(data.items) ? data.items : [];
+      setItems(nextItems);
+      await fetchDetails(nextItems.map((item) => item.ticker));
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load watchlist';
       setError(message);
@@ -90,6 +161,14 @@ export default function WatchlistPage() {
     if (!userId) return;
     void refreshWatchlist();
   }, [userId]);
+
+  useEffect(() => {
+    if (!items.length) {
+      setDetailsMap({});
+      return;
+    }
+    void fetchDetails(items.map((item) => item.ticker));
+  }, [items]);
 
   useEffect(() => {
     if (!searchOpen) return;
@@ -137,7 +216,7 @@ export default function WatchlistPage() {
       setSearchOpen(false);
       setQuery('');
       setResults([]);
-      await refreshWatchlist();
+      setItems(Array.isArray(data.items) ? data.items : []);
       setTimeout(() => setToast(null), 2500);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to add ticker';
@@ -145,6 +224,56 @@ export default function WatchlistPage() {
     } finally {
       setAddingTicker(null);
     }
+  };
+
+  const handleRemove = async (ticker: string) => {
+    if (!userId) return;
+    const confirmed = window.confirm(`Remove ${ticker} from your watchlist?`);
+    if (!confirmed) return;
+    setError(null);
+    try {
+      const res = await fetch(`/api/watchlist/${encodeURIComponent(ticker)}`, {
+        method: 'DELETE',
+        headers: { [USER_HEADER_KEY]: userId },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || `Failed to remove (${res.status})`);
+      }
+      setItems(Array.isArray(data.items) ? data.items : []);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to remove ticker';
+      setError(message);
+    }
+  };
+
+  const handleReorder = async (nextItems: WatchlistItem[]) => {
+    if (!userId) return;
+    setItems(nextItems);
+    try {
+      const res = await fetch('/api/watchlist/reorder', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', [USER_HEADER_KEY]: userId },
+        body: JSON.stringify({ tickers: nextItems.map((item) => item.ticker) }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || `Failed to reorder (${res.status})`);
+      }
+      setItems(Array.isArray(data.items) ? data.items : nextItems);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to reorder watchlist';
+      setError(message);
+      await refreshWatchlist();
+    }
+  };
+
+  const moveItem = (fromIndex: number, toIndex: number) => {
+    if (fromIndex === toIndex) return items;
+    const next = [...items];
+    const [removed] = next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, removed);
+    return next.map((item, index) => ({ ...item, position: index }));
   };
 
   return (
@@ -172,7 +301,30 @@ export default function WatchlistPage() {
 
         {error && (
           <div className="mt-4 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">
-            {error}
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span>{error}</span>
+              <button
+                type="button"
+                onClick={() => refreshWatchlist()}
+                className="inline-flex items-center gap-1 text-xs font-semibold text-red-700 hover:text-red-800"
+              >
+                <RefreshCw size={14} /> Retry
+              </button>
+            </div>
+          </div>
+        )}
+        {detailsError && (
+          <div className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span>{detailsError}</span>
+              <button
+                type="button"
+                onClick={() => fetchDetails(items.map((item) => item.ticker))}
+                className="inline-flex items-center gap-1 text-xs font-semibold text-amber-700 hover:text-amber-800"
+              >
+                <RefreshCw size={14} /> Retry data
+              </button>
+            </div>
           </div>
         )}
 
@@ -184,7 +336,7 @@ export default function WatchlistPage() {
             </div>
             <div className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
               <Sparkles size={14} />
-              <span>{loading ? 'Refreshing…' : 'Search to add'}</span>
+              <span>{loading || detailsLoading ? 'Refreshing…' : 'Search to add'}</span>
             </div>
           </div>
 
@@ -200,33 +352,105 @@ export default function WatchlistPage() {
             </div>
           ) : (
             <div className="divide-y divide-gray-100 dark:divide-gray-700">
-              {items.map((item) => (
-                <div key={item.id} className="flex items-center justify-between px-4 sm:px-6 py-4">
-                <div className="flex items-center gap-3 sm:gap-4">
-                  <div className="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 text-white font-semibold flex items-center justify-center shadow-sm overflow-hidden">
-                    {item.logoUrl ? (
-                      <Image
-                        src={item.logoUrl}
-                        alt={`${item.ticker} logo`}
-                        width={40}
-                        height={40}
-                        className="h-10 w-10 object-contain bg-white"
-                        unoptimized
-                      />
-                    ) : (
-                      item.ticker[0]
-                    )}
-                  </div>
-                    <div>
-                      <div className="font-semibold text-base">{item.ticker}</div>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">Watchlist item</p>
+              {items.map((item, index) => {
+                const summary = detailsMap[item.ticker];
+                const isLoadingRow = detailsLoading && !summary;
+                const changeClass =
+                  (summary?.changePercent ?? 0) >= 0 ? 'text-emerald-600' : 'text-rose-600';
+                const badgeTone =
+                  (summary?.changePercent ?? 0) >= 0
+                    ? 'bg-emerald-100 text-emerald-700'
+                    : 'bg-rose-100 text-rose-700';
+                return (
+                  <div
+                    key={item.id}
+                    className={`flex flex-col sm:flex-row sm:items-center gap-4 px-4 sm:px-6 py-4 group ${
+                      draggingTicker === item.ticker ? 'opacity-60' : ''
+                    }`}
+                    onDragOver={(e) => {
+                      e.preventDefault();
+                    }}
+                    onDrop={(e) => {
+                      e.preventDefault();
+                      if (!draggingTicker) return;
+                      const fromIndex = items.findIndex((row) => row.ticker === draggingTicker);
+                      const toIndex = index;
+                      const next = moveItem(fromIndex, toIndex);
+                      setDraggingTicker(null);
+                      void handleReorder(next);
+                    }}
+                    onDragEnd={() => setDraggingTicker(null)}
+                  >
+                    <div className="flex items-center gap-3 sm:gap-4 flex-1">
+                      <button
+                        type="button"
+                        className="hidden sm:inline-flex items-center justify-center h-8 w-8 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-400 hover:text-gray-600"
+                        aria-label="Drag to reorder"
+                        draggable
+                        onDragStart={(e) => {
+                          setDraggingTicker(item.ticker);
+                          e.dataTransfer.effectAllowed = 'move';
+                        }}
+                        onDragEnd={() => setDraggingTicker(null)}
+                      >
+                        <GripVertical size={16} />
+                      </button>
+                      <div className="w-12 h-12 rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 text-white font-semibold flex items-center justify-center shadow-sm overflow-hidden">
+                        {item.logoUrl ? (
+                          <Image
+                            src={item.logoUrl}
+                            alt={`${item.ticker} logo`}
+                            width={48}
+                            height={48}
+                            className="h-12 w-12 object-contain bg-white"
+                            unoptimized
+                          />
+                        ) : (
+                          item.ticker[0]
+                        )}
+                      </div>
+                      <div>
+                        <div className="font-semibold text-base">{item.ticker}</div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {item.name ?? 'Watchlist item'}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-4 ml-auto">
+                      <div className="hidden sm:block">
+                        {isLoadingRow ? (
+                          <div className="h-6 w-20 rounded-full bg-gray-100 dark:bg-gray-800 animate-pulse" />
+                        ) : (
+                          <Sparkline points={summary?.sparkline} />
+                        )}
+                      </div>
+                      <div className="text-right">
+                        {isLoadingRow ? (
+                          <>
+                            <div className="h-4 w-16 rounded-full bg-gray-100 dark:bg-gray-800 animate-pulse mb-2" />
+                            <div className="h-4 w-12 rounded-full bg-gray-100 dark:bg-gray-800 animate-pulse" />
+                          </>
+                        ) : (
+                          <>
+                            <div className="font-semibold text-sm">{formatPrice(summary?.lastPrice)}</div>
+                            <div className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ${badgeTone}`}>
+                              <span className={changeClass}>{formatPercent(summary?.changePercent)}</span>
+                            </div>
+                          </>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(item.ticker)}
+                        className="inline-flex items-center justify-center h-9 w-9 rounded-full text-rose-600 hover:bg-rose-50"
+                        aria-label={`Remove ${item.ticker}`}
+                      >
+                        <Trash2 size={16} />
+                      </button>
                     </div>
                   </div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400">
-                    Position {item.position + 1}
-                  </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </section>
@@ -269,6 +493,9 @@ export default function WatchlistPage() {
               </div>
               {searchError && (
                 <p className="mt-2 text-xs text-red-600">{searchError}</p>
+              )}
+              {maxReached && (
+                <p className="mt-2 text-xs text-amber-600">Watchlist limit reached (50). Remove a ticker to add more.</p>
               )}
             </div>
             <div className="max-h-[420px] overflow-y-auto">
@@ -318,7 +545,7 @@ export default function WatchlistPage() {
                           <button
                             type="button"
                             onClick={() => handleAdd(result.ticker)}
-                            disabled={inList || addingTicker === result.ticker}
+                            disabled={maxReached || inList || addingTicker === result.ticker}
                             className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-blue-600 text-white hover:bg-blue-500 disabled:bg-gray-400"
                             aria-label={`Add ${result.ticker}`}
                           >

--- a/src/lib/stocks/details.ts
+++ b/src/lib/stocks/details.ts
@@ -51,11 +51,14 @@ function buildSummary(snapshot: AlpacaStockSnapshot | undefined, bars: AlpacaBar
   const resolvedLatest = latestPrice ?? fallbackLatest;
   const resolvedPrev = previousClose ?? fallbackPrev;
   const changeData = calcChange(resolvedLatest, resolvedPrev);
-  const sparkline = sortedBars
+  let sparkline = sortedBars
     .slice(0, 20)
     .reverse()
     .map((bar) => bar.c)
     .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
+  if (sparkline.length < 2 && resolvedPrev !== null && resolvedLatest !== null) {
+    sparkline = [resolvedPrev, resolvedLatest];
+  }
 
   return {
     lastPrice: resolvedLatest ?? null,

--- a/src/lib/stocks/details.ts
+++ b/src/lib/stocks/details.ts
@@ -40,6 +40,11 @@ function buildSummary(snapshot: AlpacaStockSnapshot | undefined, bars: AlpacaBar
   const latestPrice = snapshot?.latestTrade?.p ?? snapshot?.minuteBar?.c ?? snapshot?.dailyBar?.c ?? null;
   const previousClose = snapshot?.prevDailyBar?.c ?? null;
   const changeData = calcChange(latestPrice, previousClose);
+  const sparkline = [...bars]
+    .slice(0, 20)
+    .reverse()
+    .map((bar) => bar.c)
+    .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
 
   return {
     lastPrice: latestPrice ?? null,
@@ -47,6 +52,7 @@ function buildSummary(snapshot: AlpacaStockSnapshot | undefined, bars: AlpacaBar
     change: changeData.change,
     changePercent: changeData.changePercent,
     lastTradeTime: snapshot?.latestTrade?.t ?? null,
+    sparkline: sparkline.length ? sparkline : undefined,
     dayRange: snapshot?.dailyBar
       ? {
           low: snapshot.dailyBar.l,
@@ -164,4 +170,3 @@ export function buildStockDetails({
     isPartial: warnings.length > 0,
   };
 }
-

--- a/src/lib/stocks/details.ts
+++ b/src/lib/stocks/details.ts
@@ -39,16 +39,27 @@ function findRangePosition(current: number | null, bars: AlpacaBar[] | undefined
 function buildSummary(snapshot: AlpacaStockSnapshot | undefined, bars: AlpacaBar[]): StockDetailsSummary {
   const latestPrice = snapshot?.latestTrade?.p ?? snapshot?.minuteBar?.c ?? snapshot?.dailyBar?.c ?? null;
   const previousClose = snapshot?.prevDailyBar?.c ?? null;
-  const changeData = calcChange(latestPrice, previousClose);
-  const sparkline = [...bars]
+  const sortedBars = [...bars].sort((a, b) => {
+    const aTime = a.t ? new Date(a.t).getTime() : 0;
+    const bTime = b.t ? new Date(b.t).getTime() : 0;
+    return bTime - aTime;
+  });
+  const latestBar = sortedBars[0];
+  const prevBar = sortedBars[1];
+  const fallbackLatest = latestBar?.c ?? null;
+  const fallbackPrev = prevBar?.c ?? latestBar?.o ?? null;
+  const resolvedLatest = latestPrice ?? fallbackLatest;
+  const resolvedPrev = previousClose ?? fallbackPrev;
+  const changeData = calcChange(resolvedLatest, resolvedPrev);
+  const sparkline = sortedBars
     .slice(0, 20)
     .reverse()
     .map((bar) => bar.c)
     .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
 
   return {
-    lastPrice: latestPrice ?? null,
-    previousClose,
+    lastPrice: resolvedLatest ?? null,
+    previousClose: resolvedPrev ?? null,
     change: changeData.change,
     changePercent: changeData.changePercent,
     lastTradeTime: snapshot?.latestTrade?.t ?? null,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -309,6 +309,7 @@ export interface StockDetailsSummary {
   change: number | null;
   changePercent: number | null;
   lastTradeTime?: string | null;
+  sparkline?: number[];
   dayRange?: StockValueRange;
   fiftyTwoWeekRange?: StockValueRangePosition;
   volume?: StockVolumeSnapshot;
@@ -390,6 +391,7 @@ export interface WatchlistItem {
   position: number;
   createdAt: string;
   logoUrl?: string | null;
+  name?: string | null;
 }
 
 export interface WatchlistResponse {


### PR DESCRIPTION
## Summary
- render watchlist items as rich cards with price, % change badge, and sparkline
- fetch stock details per ticker for live data (with loading skeleton + retry)
- enable drag-to-reorder via handle and persist ordering
- enable remove with confirmation

## Testing
- not run (UI + API changes)
